### PR TITLE
Change ownership of .dart_tool to allow non-root usage of flutter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ All user visible changes to this project will be documented in this file. This p
 
 
 
+## main
+
+[Diff](/../../compare/3.29.3-androidsdk35-r0...main)
+
+### Changed
+
+- Changed `flutter_tools/.dart_tool` owner to `1000` user. ([#21], [#20])
+
+[#20]: /../../issues/20
+[#21]: /../../pull/21
+
+
+
+
 ## [3.29.3-androidsdk35-r0] · 2025-04-16
 [3.29.3-androidsdk35-r0]: /../../tree/3.29.3-androidsdk35-r0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,4 +40,5 @@ RUN apt-get update \
  && flutter --version \
     \
  && rm -rf /var/lib/apt/lists/* \
-           /tmp/*
+           /tmp/* \
+ && chown -R 1000:1000 /usr/local/flutter/packages/flutter_tools/.dart_tool/

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,8 @@ RUN apt-get update \
  && (yes | flutter doctor --android-licenses) \
  && flutter --version \
     \
+ # Make Flutter tools available for non-root usage
+ && chown -R 1000:1000 /usr/local/flutter/packages/flutter_tools/.dart_tool/ \
+    \
  && rm -rf /var/lib/apt/lists/* \
-           /tmp/* \
- && chown -R 1000:1000 /usr/local/flutter/packages/flutter_tools/.dart_tool/
+           /tmp/*

--- a/README.md
+++ b/README.md
@@ -54,6 +54,16 @@ docker run --rm -v /my/rust/project:/app -w /app instrumentisto/flutter \
 ```
 
 
+### Non-`root` usage
+
+If you cannot run this image as `root`, use the `1000` user instead, which owns `flutter_tools` inside the image:
+```bash
+docker run --rm --user 1000:1000 \
+           -v /my/rust/project:/app -w /app instrumentisto/flutter \
+    flutter doctor
+```
+
+
 
 
 ## Image tags

--- a/tests/main.bats
+++ b/tests/main.bats
@@ -32,6 +32,12 @@
   [ "$status" -eq 0 ]
 }
 
+@test "flutter doctor runs ok by non-root" {
+  run docker run --rm --pull never --user 1000:1000 --entrypoint sh $IMAGE -c \
+    'flutter doctor'
+  [ "$status" -eq 0 ]
+}
+
 @test "flutter has correct version" {
   run docker run --rm --pull never --entrypoint sh $IMAGE -c \
     "flutter --version | grep 'Flutter ' | cut -d ' ' -f 2 | tr -d ' '"


### PR DESCRIPTION
This fixes https://github.com/instrumentisto/flutter-docker-image/issues/20 . Tested locally and after building, i can launch the container with `--user 1000:1000` and execute `flutter doctor` without issues.