### PR TITLE
Upgrade Flutter to 3.35.2 version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All user visible changes to this project will be documented in this file. This p
 
 
 
+## [3.35.2-androidsdk35-r0] · 2025-08-26
+[3.35.2-androidsdk35-r0]: /../../tree/3.35.2-androidsdk35-r0
+
+[Diff](/../../compare/3.35.1-androidsdk35-r0...3.35.2-androidsdk35-r0)
+
+### Upgraded
+
+- [Flutter] 3.35.2: <https://github.com/flutter/flutter/blob/3.35.2/CHANGELOG.md#3352>
+
+
+
+
 ## [3.35.1-androidsdk35-r0] · 2025-08-15
 [3.35.1-androidsdk35-r0]: /../../tree/3.35.1-androidsdk35-r0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 ARG android_sdk_ver=35
 FROM ghcr.io/cirruslabs/android-sdk:${android_sdk_ver}
 
-ARG flutter_ver=3.35.1
+ARG flutter_ver=3.35.2
 ARG build_rev=0
 
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Based on [`ghcr.io/cirruslabs/android-sdk` Docker image][2].
 
 ## Supported tags and respective `Dockerfile` links
 
-- [`3.35.1-androidsdk35-r0`, `3.35.1`, `3.35`, `3`, `latest`][201]
+- [`3.35.2-androidsdk35-r0`, `3.35.2`, `3.35`, `3`, `latest`][201]
 
 
 


### PR DESCRIPTION
I tried to follow how the upgrade was done before on this repo. Let me know if anything needs changing :)