### PR TITLE
Add multi-arch builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,9 +27,7 @@ RUN apt-get update \
             pkg-config \
     \
  # Install Flutter itself
- && curl -fL -o /tmp/flutter.tar.xz \
-         https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_${flutter_ver}-stable.tar.xz \
- && tar -xf /tmp/flutter.tar.xz -C /usr/local/ \
+ && git clone --branch ${flutter_ver} --single-branch https://github.com/flutter/flutter.git /usr/local/flutter \
  && git config --global --add safe.directory /usr/local/flutter \
  && flutter config --enable-android \
                    --enable-linux-desktop \

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ github_url := $(strip $(or $(GITHUB_SERVER_URL),https://github.com))
 github_repo := $(strip $(or $(GITHUB_REPOSITORY),$(OWNER)/$(NAME)-docker-image))
 
 docker.image:
-	docker build --network=host --force-rm \
+	docker buildx build --platform linux/amd64,linux/arm64 --network=host --force-rm \
 		$(if $(call eq,$(no-cache),yes),--no-cache --pull,) \
 		--build-arg flutter_ver=$(FLUTTER_VER) \
 		--build-arg android_sdk_ver=$(ANDROID_SDK_VER) \


### PR DESCRIPTION
By pulling from github instead of compiled packages we can install flutter/dart on x86 and arm devices

Flutter does support this because they have builds for apple silicon but not for linux

```
$ flutter doctor
Doctor summary (to see all details, run flutter doctor -v):
[!] Flutter (Channel [user-branch], 3.32.8, on Ubuntu 24.04.3 LTS 6.10.14-linuxkit, locale en_US.UTF-8)
    ! Flutter version 3.32.8 on channel [user-branch] at /usr/local/flutter
      Currently on an unknown channel. Run `flutter channel` to switch to an official channel.
      If that doesn't fix the issue, reinstall Flutter by following instructions at https://flutter.dev/setup.
    ! Upstream repository unknown source is not a standard remote.
      Set environment variable "FLUTTER_GIT_URL" to unknown source to dismiss this error.
[✓] Android toolchain - develop for Android devices (Android SDK version 35.0.0)
[✗] Chrome - develop for the web (Cannot find Chrome executable at google-chrome)
    ! Cannot find Chrome. Try setting CHROME_EXECUTABLE to a Chrome executable.
[✓] Linux toolchain - develop for Linux desktop
    ! Unable to access driver information using 'eglinfo'.
      It is likely available from your distribution (e.g.: apt install mesa-utils)
[!] Android Studio (not installed)
[☠] Connected device (the doctor check crashed)
    ✗ Due to an error, the doctor check did not complete. If the error message below is not helpful, please let us know about this issue at https://github.com/flutter/flutter/issues.
    ✗ Error: Unable to run "adb", check your Android SDK installation and ANDROID_HOME environment variable: /opt/android-sdk-linux/platform-tools/adb
      Error details: Process exited abnormally with exit code 255:
      qemu-x86_64: Could not open '/lib64/ld-linux-x86-64.so.2': No such file or directory
[✓] Network resources

! Doctor found issues in 4 categories.
```


```
$ dart --version
Dart SDK version: 3.8.1 (stable) (Wed May 28 00:47:25 2025 -0700) on "linux_arm64"
```

I am not 100% sure if the existing docker build and publishing scripts will work

Been using the modified docker image as a dev container on a mac, works quicker than x86

Building APKs fails with 
'/lib64/ld-linux-x86-64.so.2': No such file or directory